### PR TITLE
Fix YukiHook duplicate class error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,9 +149,7 @@ dependencies {
 
     // YukiHook API with KavaRef
     implementation(libs.yukihook.api)
-    ksp(libs.yukihook.ksp) {
-        exclude(group = "com.highcapable.yukihookapi", module = "api")
-    }
+    ksp(libs.yukihook.ksp)
 
     // KavaRef for YukiHook
 
@@ -249,4 +247,9 @@ configurations.all {
     resolutionStrategy {
         force("org.jetbrains:annotations:26.0.2-1")
     }
+}
+
+// Exclude YukiHook API from KSP configurations to avoid duplicate class errors
+configurations.matching { it.name.startsWith("ksp") }.configureEach {
+    exclude(group = "com.highcapable.yukihookapi", module = "api")
 }


### PR DESCRIPTION
- Remove inline exclude from ksp() call (doesn't work)
- Add configuration-level exclusion for all ksp configurations
- Excludes api module from ksp to prevent YukiHookAPIProperties duplicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration by refactoring dependency exclusion settings to apply globally across KSP-related configurations, improving build consistency without affecting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->