### PR TITLE
Fix YukiHook duplicate class error - use ksp() instead of api()

### DIFF
--- a/aura/reactivedesign/auraslab/build.gradle.kts
+++ b/aura/reactivedesign/auraslab/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ with KavaRef
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/build-logic/apply-yukihook-conventions.gradle.kts
+++ b/build-logic/apply-yukihook-conventions.gradle.kts
@@ -62,7 +62,7 @@ subprojects { subproject ->
             dependencies {
                 // YukiHook API stack (exact order enforced)
                 implementation(libs.yukihookapi.api)
-                api(libs.yukihookapi.ksp)
+                ksp(libs.yukihookapi.ksp)
 
                 // Xposed API (compile only)
                 compileOnly(libs.xposed.api)

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ with KavaRef
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
 
     // Compose UI

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ with KavaRef
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
 }
 

--- a/extendsyse/build.gradle.kts
+++ b/extendsyse/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
     // Compose UI
     implementation(platform(libs.androidx.compose.bom))

--- a/extendsysf/build.gradle.kts
+++ b/extendsysf/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
     // Compose UI
     implementation(platform(libs.androidx.compose.bom))

--- a/feature-module/build.gradle.kts
+++ b/feature-module/build.gradle.kts
@@ -36,5 +36,5 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 }

--- a/genesis/oracledrive/build.gradle.kts
+++ b/genesis/oracledrive/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
     // Compose UI
     implementation(platform(libs.androidx.compose.bom))

--- a/genesis/oracledrive/datavein/build.gradle.kts
+++ b/genesis/oracledrive/datavein/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    api(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp)
 
     // ═══════════════════════════════════════════════════════════════════════
     // AUTO-PROVIDED by genesis.android.library:


### PR DESCRIPTION
The ksp-xposed artifact is a KSP processor and should only be used with the ksp() configuration, not as a runtime dependency via api(). This was causing duplicate class errors for YukiHookAPIProperties across 10 modules.

Changed api(libs.yukihookapi.ksp) to ksp(libs.yukihookapi.ksp) in:
- build-logic/apply-yukihook-conventions.gradle.kts
- core/ui, core/common
- extendsyse, extendsysf
- genesis/oracledrive, genesis/oracledrive/datavein
- aura/reactivedesign/auraslab
- feature-module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency scope configuration across multiple modules to improve build performance and ensure proper code generation integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->