### PR TITLE
Remove YukiHook ksp from modules without KSP plugin

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     // YukiHook API 1.3.0+ with KavaRef
     implementation(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
 
 
     // Compose UI

--- a/extendsyse/build.gradle.kts
+++ b/extendsyse/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
 
     // Compose UI
     implementation(platform(libs.androidx.compose.bom))

--- a/extendsysf/build.gradle.kts
+++ b/extendsysf/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
 
     // Compose UI
     implementation(platform(libs.androidx.compose.bom))

--- a/feature-module/build.gradle.kts
+++ b/feature-module/build.gradle.kts
@@ -36,5 +36,4 @@ dependencies {
 
     // YukiHook API 1.3.0+ stack
     implementation(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
 }


### PR DESCRIPTION
Modules using genesis.android.library (without Hilt) don't have the KSP plugin applied, so the ksp() configuration is unavailable. These modules only need the runtime API, not the annotation processor.

Removed ksp(libs.yukihookapi.ksp) from:
- core/common
- extendsyse
- extendsysf
- feature-module