### PR TITLE
Fix additional import path errors for Hilt DI

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/animations/HomeScreenTransitionManager.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/animations/HomeScreenTransitionManager.kt
@@ -5,7 +5,7 @@ import dev.aurakai.auraframefx.services.YukiHookServiceManager
 import dev.aurakai.auraframefx.system.common.ImageResourceManager
 import dev.aurakai.auraframefx.system.homescreen.model.HomeScreenTransitionConfig
 import dev.aurakai.auraframefx.system.overlay.ShapeManager
-import dev.aurakai.auraframefx.system.overlay.SystemOverlayManager
+import dev.aurakai.auraframefx.system.ui.SystemOverlayManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.json.JSONException

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/LockScreenCustomizer.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/LockScreenCustomizer.kt
@@ -7,7 +7,7 @@ import dev.aurakai.auraframefx.system.lockscreen.model.LockScreenConfig
 import dev.aurakai.auraframefx.system.lockscreen.model.LockScreenElementType
 import dev.aurakai.auraframefx.system.overlay.model.OverlayShape
 import dev.aurakai.auraframefx.ui.model.ImageResource
-import dev.aurakai.auraframefx.ui.theme.ThemeManager
+import dev.aurakai.auraframefx.theme.ThemeManager
 import dev.aurakai.auraframefx.utils.AuraFxLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/dev/aurakai/auraframefx/cascade/CascadeZOrderPlayground.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/cascade/CascadeZOrderPlayground.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import dev.aurakai.auraframefx.ai.agents.CascadeAgent
+import dev.aurakai.auraframefx.cascade.CascadeAgent
 import dev.aurakai.auraframefx.model.agent_states.ProcessingState
 import dev.aurakai.auraframefx.model.agent_states.VisionState
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/GenesisBridgeService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/GenesisBridgeService.kt
@@ -24,9 +24,9 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import dev.aurakai.auraframefx.models.AiRequest
 import dev.aurakai.auraframefx.model.AgentResponse
-import dev.aurakai.auraframefx.context.ContextManager
+import dev.aurakai.auraframefx.ai.context.ContextManager
 import dev.aurakai.auraframefx.security.SecurityContext
-import dev.aurakai.auraframefx.aura.AuraFxLogger
+import dev.aurakai.auraframefx.utils.AuraFxLogger
 import javax.inject.Inject
 import javax.inject.Singleton
 


### PR DESCRIPTION
- CascadeDebugViewModel: fixed CascadeAgent import (ai.agents -> cascade)
- HomeScreenTransitionManager: fixed SystemOverlayManager import (system.overlay -> system.ui)
- LockScreenCustomizer: fixed ThemeManager import (ui.theme -> theme)
- GenesisBridgeService: fixed AuraFxLogger import (aura -> utils) and ContextManager import

These fixes address more KSP processing errors where Hilt couldn't resolve constructor parameter types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization and package structure improvements to enhance maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->