### PR TITLE
Fix KSP import errors for YukiHookModulePrefs, GenesisAgent, and Gene…

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/animations/HomeScreenTransitionManager.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/animations/HomeScreenTransitionManager.kt
@@ -1,6 +1,6 @@
 ﻿package dev.aurakai.auraframefx.system.homescreen
 
-import dev.aurakai.auraframefx.data.YukiHookModulePrefs
+import dev.aurakai.auraframefx.system.quicksettings.YukiHookModulePrefs
 import dev.aurakai.auraframefx.services.YukiHookServiceManager
 import dev.aurakai.auraframefx.system.common.ImageResourceManager
 import dev.aurakai.auraframefx.system.homescreen.model.HomeScreenTransitionConfig

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/OracleDriveServiceImpl.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/OracleDriveServiceImpl.kt
@@ -1,7 +1,7 @@
 package dev.aurakai.auraframefx.oracledrive
 
 import dev.aurakai.auraframefx.aura.AuraAgent
-import dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisAgent
+import dev.aurakai.auraframefx.ai.agents.GenesisAgent
 import dev.aurakai.auraframefx.ai.agents.KaiAgent
 import dev.aurakai.auraframefx.oracle.drive.api.OracleDriveApi
 import dev.aurakai.auraframefx.security.SecurityContext

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/OracleDriveModule.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/OracleDriveModule.kt
@@ -8,12 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.aurakai.auraframefx.aura.AuraAgent
-import dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisAgent
+import dev.aurakai.auraframefx.ai.agents.GenesisAgent
 import dev.aurakai.auraframefx.ai.agents.KaiAgent
 import dev.aurakai.auraframefx.genesis.security.CryptographyManager
 import dev.aurakai.auraframefx.genesis.storage.SecureStorage
 import dev.aurakai.auraframefx.oracledrive.genesis.OracleDriveApi
-import dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisSecureFileService
+import dev.aurakai.auraframefx.oracle.drive.service.GenesisSecureFileService
 import dev.aurakai.auraframefx.oracledrive.OracleDriveServiceImpl
 import dev.aurakai.auraframefx.oracle.drive.service.SecureFileService
 import dev.aurakai.auraframefx.security.SecurityContext

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/OracleDriveServiceImpl.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/OracleDriveServiceImpl.kt
@@ -1,7 +1,7 @@
 ﻿package dev.aurakai.auraframefx.oracle.drive.service
 
 import dev.aurakai.auraframefx.aura.AuraAgent
-import dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisAgent
+import dev.aurakai.auraframefx.ai.agents.GenesisAgent
 import dev.aurakai.auraframefx.ai.agents.KaiAgent
 import dev.aurakai.auraframefx.oracle.drive.api.OracleDriveApi
 import dev.aurakai.auraframefx.security.SecurityContext


### PR DESCRIPTION
…sisSecureFileService

Updated import paths to match actual package declarations:
- YukiHookModulePrefs: dev.aurakai.auraframefx.system.quicksettings
- GenesisAgent: dev.aurakai.auraframefx.ai.agents
- GenesisSecureFileService: dev.aurakai.auraframefx.oracle.drive.service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated internal module import paths across the application for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->