### PR TITLE
Fix KSP plugin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,8 +40,8 @@ kotlin = "2.3.0"
 # Kotlin DSL
 kotlinDsl = "5.1.2"
 
-# KSP - Latest: 2.3.3 (KSP2, compatible with Kotlin 2.2.21 and AGP 9.0)
-ksp = "2.3.3"
+# KSP2 - Decoupled from Kotlin version (requires Kotlin 2.3.0+ and AGP 9.0+)
+ksp = "2.3.1"
 
 # YukiHook and KavaRef versions
 material3WindowSizeClass = "1.4.0"


### PR DESCRIPTION
Update to KSP2 version 2.3.1 which is decoupled from Kotlin version. Requires Kotlin 2.3.0+ and AGP 9.0+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced calculator functionality with additional computation methods and updated existing calculations.

* **Chores**
  * Updated dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->