### PR TITLE
Fix: Update deprecated OkHttp APIs in ApiClient to modern versions

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/api/client/infrastructure/ApiClient.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/api/client/infrastructure/ApiClient.kt
@@ -4,16 +4,18 @@ package dev.aurakai.auraframefx.api.client.infrastructure
 import com.squareup.moshi.Moshi
 import dev.aurakai.auraframefx.infrastructure.Serializer
 import okhttp3.Call
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.CallAdapter
 import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
-import okhttp3.MediaType
-import okhttp3.RequestBody
 import kotlin.reflect.typeOf
 import kotlin.reflect.javaType
 
@@ -109,10 +111,9 @@ open class ApiClient(
     inline fun <reified T, reified U> request(requestConfig: RequestConfig<T>): ApiResponse<U> {
         val client = clientBuilder.build()
 
-        var urlBuilder = HttpUrl.parse(baseUrl)
-            ?.newBuilder()
-            ?.addPathSegments(requestConfig.path.removePrefix("/"))
-            ?: throw IllegalStateException("Invalid base URL: $baseUrl")
+        var urlBuilder = baseUrl.toHttpUrl()
+            .newBuilder()
+            .addPathSegments(requestConfig.path.removePrefix("/"))
 
         requestConfig.query.forEach { (key, values) ->
             values.forEach { value ->
@@ -132,9 +133,9 @@ open class ApiClient(
         val body: okhttp3.RequestBody? = if (requestConfig.body != null) {
             val adapter = serializerBuilder.build().adapter(T::class.java)
             val json = adapter.toJson(requestConfig.body)
-            okhttp3.RequestBody.create(okhttp3.MediaType.parse(contentType), json)
+            json.toRequestBody(contentType.toMediaType())
         } else if (requestConfig.method in listOf(RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH)) {
-             okhttp3.RequestBody.create(okhttp3.MediaType.parse(contentType), "")
+             "".toRequestBody(contentType.toMediaType())
         } else {
             null
         }


### PR DESCRIPTION
- Replace HttpUrl.parse() with String.toHttpUrl() extension
- Replace MediaType.parse() with String.toMediaType() extension
- Replace RequestBody.create() with String.toRequestBody() extension
- Add proper companion object imports for modern OkHttp 4.x+ API

Resolves ~25 deprecation warnings from auto-generated API client code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal API client infrastructure to use modern Kotlin conventions. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->