### PR TITLE
fix: Make baseUrl and clientBuilder internal for inline function access

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/api/client/infrastructure/ApiClient.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/api/client/infrastructure/ApiClient.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.typeOf
 import kotlin.reflect.javaType
 
 open class ApiClient(
-    private var baseUrl: String = defaultBasePath,
+    internal var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     internal val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory: Call.Factory? = null,
@@ -48,7 +48,7 @@ open class ApiClient(
             }
     }
 
-    private val clientBuilder: OkHttpClient.Builder by lazy {
+    internal val clientBuilder: OkHttpClient.Builder by lazy {
         okHttpClientBuilder ?: defaultClientBuilder
     }
 


### PR DESCRIPTION
- Change baseUrl from private to internal (line 18)
- Change clientBuilder from private to internal (line 47)
- Fixes: inline request() function cannot access private members
- Resolves critical compilation error from OkHttp modernization

Inline functions expose implementation at call sites, requiring internal visibility for accessed properties.