### PR TITLE
fix: Change OverlayShape.RECTANGLE to ROUNDED_RECTANGLE

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/QuickSettingsCustomizer.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/QuickSettingsCustomizer.kt
@@ -72,7 +72,7 @@ class QuickSettingsCustomizer @Inject constructor(
             currentTiles.add(QuickSettingsTileConfig(
                 id = tileId,
                 label = tileId,
-                shape = OverlayShape.RECTANGLE,
+                shape = OverlayShape.ROUNDED_RECTANGLE,
                 animation = animation
             ))
         }
@@ -153,7 +153,7 @@ class QuickSettingsCustomizer @Inject constructor(
             val shapeStr = prefs.getString("tile_shape_$tileId", null)
             val animationStr = prefs.getString("tile_animation_$tileId", null)
 
-            val shape = shapeStr?.let { OverlayShape.valueOf(it) } ?: OverlayShape.RECTANGLE
+            val shape = shapeStr?.let { OverlayShape.valueOf(it) } ?: OverlayShape.ROUNDED_RECTANGLE
             val animation = animationStr?.let { QuickSettingsAnimation.valueOf(it) } ?: QuickSettingsAnimation.FADE
 
             tiles.add(QuickSettingsTileConfig(


### PR DESCRIPTION
QuickSettingsCustomizer.kt:
- Line 75: RECTANGLE → ROUNDED_RECTANGLE
- Line 156: RECTANGLE → ROUNDED_RECTANGLE
- Fixes: Unresolved reference RECTANGLE (enum value doesn't exist)

OverlayShape enum only has: CIRCLE, SQUARE, HEXAGON, ROUNDED_RECTANGLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * New tiles now default to rounded rectangle shape instead of rectangular shape.
  * Existing tiles retain their current shapes when updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->