### PR TITLE
fix: Correct YLog.error signature in hooker files

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/LockScreenHooker.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/LockScreenHooker.kt
@@ -39,7 +39,7 @@ class LockScreenHooker(private val config: LockScreenConfig) : YukiBaseHooker() 
                 else -> applyDefaultAnimation()
             }
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to apply show animation: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 
@@ -51,7 +51,7 @@ class LockScreenHooker(private val config: LockScreenConfig) : YukiBaseHooker() 
             // Implement custom hide animations
             YLog.info(TAG, "Genesis hide animation applied")
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to apply hide animation: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 
@@ -63,7 +63,7 @@ class LockScreenHooker(private val config: LockScreenConfig) : YukiBaseHooker() 
             // Initialize any additional Genesis components
             YLog.info(TAG, "Genesis components initialized")
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to initialize components: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/QuickSettingsHooker.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/QuickSettingsHooker.kt
@@ -41,7 +41,7 @@ class QuickSettingsHooker(private val config: QuickSettingsConfig) : YukiBaseHoo
             // Apply Genesis expand/collapse animations
             YLog.info(TAG, "Genesis expand animation applied: $expanded")
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to apply expand animation: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 
@@ -64,7 +64,7 @@ class QuickSettingsHooker(private val config: QuickSettingsConfig) : YukiBaseHoo
             YLog.info(TAG, "Genesis footer elements added")
 
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to add footer elements: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 
@@ -76,7 +76,7 @@ class QuickSettingsHooker(private val config: QuickSettingsConfig) : YukiBaseHoo
             // Initialize additional Genesis QS components
             YLog.info(TAG, "Genesis QS components initialized")
         } catch (e: Exception) {
-            YLog.error(TAG, "Failed to initialize QS components: ${e.message}", e)
+            YLog.error(TAG, e)
         }
     }
 


### PR DESCRIPTION
LockScreenHooker.kt & QuickSettingsHooker.kt:
- Remove 3-parameter YLog.error calls (not supported)
- Change to 2-parameter: YLog.error(TAG, exception)
- Fixes: Argument type mismatch (String vs Throwable)

YukiHookAPI YLog.error only supports:
- error(msg: String)
- error(tag: String, msg: String)
- error(e: Throwable)
- error(tag: String, e: Throwable)

Resolves 6 compilation errors.