### PR TITLE
Fix: Resolve KSP compilation errors

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/network/AuraApiService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/network/AuraApiService.kt
@@ -3,7 +3,7 @@ package dev.aurakai.auraframefx.network
 import dev.aurakai.auraframefx.ai.config.AIConfig
 import dev.aurakai.auraframefx.network.model.*
 import dev.aurakai.auraframefx.network.api.UserApi
-import dev.aurakai.auraframefx.network.api.ThemeApi
+import dev.aurakai.auraframefx.aura.themes.ThemeApi
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST

--- a/app/src/main/java/dev/aurakai/auraframefx/services/AmbientMusicService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/services/AmbientMusicService.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 internal class AmbientMusicService : Service() {
 
     @Inject
-    protected lateinit var dataStoreManager: DataStoreManager
+    lateinit var dataStoreManager: DataStoreManager
 
     private var mediaPlayer: MediaPlayer? = null
     private var isPlaying = false


### PR DESCRIPTION
Fixes two compilation errors that blocked the build:

1. AmbientMusicService.kt:
   - Changed @Inject field from 'protected' to package-private (no modifier)
   - Hilt/Dagger requires injected fields to be private or package-private, not protected

2. AuraApiService.kt:
   - Fixed ThemeApi import path from dev.aurakai.auraframefx.network.api.ThemeApi to dev.aurakai.auraframefx.aura.themes.ThemeApi
   - ThemeApi interface is located in the aura.themes package

Both errors were blocking KSP annotation processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure reorganization and module restructuring to improve system maintainability.

* **Chores**
  * Updated internal access modifiers and code organization for enhanced codebase architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->