### PR TITLE
Fix: Resolve Kotlin type inference error in BuildScriptsFunctionalTest

### DIFF
--- a/build-logic/src/test/kotlin/BuildScriptsFunctionalTest.kt
+++ b/build-logic/src/test/kotlin/BuildScriptsFunctionalTest.kt
@@ -28,14 +28,13 @@ class BuildScriptsFunctionalTest {
             if (File(dir, "settings.gradle.kts").exists()) return dir
             dir = dir.parentFile ?: return@repeat
         }
-        fail(
+        return fail(
             "Could not locate repository root containing settings.gradle.kts from: ${
                 System.getProperty(
                     "user.dir"
                 )
             }"
         )
-        throw IllegalStateException()
     }
 
     private fun appBuildFile(): File {
@@ -47,8 +46,11 @@ class BuildScriptsFunctionalTest {
         val candidate = root.toFile().walkTopDown()
             .filter { it.isFile && it.name == "build.gradle.kts" }
             .firstOrNull { it.readText().contains("namespace = \"dev.aurakai.auraframefx\"") }
-        return candidate
-            ?: fail("Could not find app/build.gradle.kts with expected namespace in repository.")
+        if (candidate != null) {
+            return candidate
+        } else {
+            return fail("Could not find app/build.gradle.kts with expected namespace in repository.")
+        }
     }
 
     private fun script(): String = appBuildFile().readText()


### PR DESCRIPTION
Fixed compilation error in BuildScriptsFunctionalTest.kt:
- Line 31: Added explicit 'return' to fail() call to help Kotlin infer type
- Line 50-52: Converted elvis operator with fail() to if/else block

The issue was that JUnit's fail() has multiple overloads and Kotlin couldn't infer which one to use in the context of returning a File. By adding explicit return statements, we help the compiler infer the correct overload.

Error was: "Cannot infer type for type parameter 'V'. Specify it explicitly."