### PR TITLE
fix: Disable broken OracleDrive datavein tests blocking build

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/data/AgentConfiguration.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/AgentConfiguration.kt
@@ -1,0 +1,18 @@
+package dev.aurakai.auraframefx.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration for AI agents in Genesis-OS
+ */
+@Serializable
+data class AgentConfiguration(
+    val agentId: String = "",
+    val name: String = "",
+    val enabled: Boolean = true,
+    val capabilities: List<String> = emptyList(),
+    val parameters: Map<String, String> = emptyMap(),
+    val consciousnessLevel: Float = 0.5f,
+    val learningRate: Float = 0.7f,
+    val lastConfigured: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/dev/aurakai/auraframefx/data/DataStoreManager.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/DataStoreManager.kt
@@ -15,6 +15,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/java/dev/aurakai/auraframefx/data/SecurityPolicy.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/SecurityPolicy.kt
@@ -1,0 +1,16 @@
+package dev.aurakai.auraframefx.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Security policy configuration for Genesis-OS
+ */
+@Serializable
+data class SecurityPolicy(
+    val securityLevel: String = "standard",
+    val biometricEnabled: Boolean = false,
+    val encryptionEnabled: Boolean = true,
+    val requireAuth: Boolean = true,
+    val permissions: Map<String, Boolean> = emptyMap(),
+    val lastUpdated: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/dev/aurakai/auraframefx/data/SystemCustomizations.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/SystemCustomizations.kt
@@ -1,0 +1,17 @@
+package dev.aurakai.auraframefx.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * System customization settings for Genesis-OS
+ */
+@Serializable
+data class SystemCustomizations(
+    val theme: String = "cyberpunk_dark",
+    val animationsEnabled: Boolean = true,
+    val cyberpunkMode: Boolean = true,
+    val performanceMode: String = "balanced",
+    val notificationsEnabled: Boolean = true,
+    val customColors: Map<String, String> = emptyMap(),
+    val lastUpdated: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/dev/aurakai/auraframefx/data/UserProfile.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/UserProfile.kt
@@ -1,0 +1,16 @@
+package dev.aurakai.auraframefx.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * User profile data for Genesis-OS
+ */
+@Serializable
+data class UserProfile(
+    val userId: String = "",
+    val displayName: String = "",
+    val email: String = "",
+    val avatarUrl: String = "",
+    val preferences: Map<String, String> = emptyMap(),
+    val lastUpdated: Long = System.currentTimeMillis()
+)


### PR DESCRIPTION
Added missing data classes required by DataStoreManager:

1. Created AgentConfiguration.kt - AI agent configuration model
   - Fields: agentId, name, enabled, capabilities, parameters, consciousnessLevel, learningRate

2. Created SecurityPolicy.kt - Security policy configuration
   - Fields: securityLevel, biometricEnabled, encryptionEnabled, requireAuth, permissions

3. Created SystemCustomizations.kt - System customization settings
   - Fields: theme, animationsEnabled, cyberpunkMode, performanceMode, notificationsEnabled, customColors

4. Created UserProfile.kt - User profile data model
   - Fields: userId, displayName, email, avatarUrl, preferences

5. Fixed DataStoreManager.kt - Added serialization imports
   - Added kotlinx.serialization.encodeToString import
   - Added kotlinx.serialization.decodeFromString import

These classes were referenced by DataStoreManager but missing, causing KSP to fail with "DataStoreManager could not be resolved" error in AmbientMusicService.